### PR TITLE
Change converters API to reduce redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ match file.convert(target_format) {
 }
 ```
 
-You can use the underneath converters if you don't want to use std::fs, but pure data:
+You can use the underneath converters if you don't want to use bytes vectors instead of std::fs:
 ```rust
 fn get_input_data() -> Vec<u8> {
     ...
@@ -33,7 +33,7 @@ fn main() {
     let input = get_input_data();
     let mut output = Vec::<u8>::new();
 
-    PngConverter.to_jpeg(&input, &mut output).expect("Conversion error");
+    PngConverter.process(&input, &mut output, Format::Jpeg).expect("Conversion error");
     
     // or in a more generic way
     let source_format = Format::Png;

--- a/src/converter/img/bmp.rs
+++ b/src/converter/img/bmp.rs
@@ -11,22 +11,24 @@ pub use crate::converter_info::BmpConverter;
 impl Converter for BmpConverter {}
 
 impl ConverterImpl for BmpConverter {
-    fn to_bmp(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        output.clone_from(input);
-        Ok(())
+    fn process(
+        &self,
+        input: &Vec<u8>,
+        output: &mut Vec<u8>,
+        target_format: Format,
+    ) -> Result<(), ConversionError> {
+        match target_format {
+            Format::Bmp => self.to_same_format(input, output),
+            Format::Tiff | Format::Png | Format::Jpeg | Format::Gif => {
+                wrapper::image_crate_conversion(input, output, target_format.into())
+            }
+            Format::Pdf => self.to_pdf(input, output),
+            _ => Err(ConversionError::UnsupportedOperation),
+        }
     }
-    fn to_tiff(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Tiff)
-    }
-    fn to_png(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Png)
-    }
-    fn to_jpeg(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Jpeg)
-    }
-    fn to_gif(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Gif)
-    }
+}
+
+impl BmpConverter {
     fn to_pdf(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
         let mut converter = QueueConverter::new();
         converter.push(Format::Png);

--- a/src/converter/img/gif.rs
+++ b/src/converter/img/gif.rs
@@ -11,22 +11,24 @@ pub use crate::converter_info::GifConverter;
 impl Converter for GifConverter {}
 
 impl ConverterImpl for GifConverter {
-    fn to_gif(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        output.clone_from(input);
-        Ok(())
+    fn process(
+        &self,
+        input: &Vec<u8>,
+        output: &mut Vec<u8>,
+        target_format: Format,
+    ) -> Result<(), ConversionError> {
+        match target_format {
+            Format::Gif => self.to_same_format(input, output),
+            Format::Tiff | Format::Png | Format::Jpeg | Format::Bmp => {
+                wrapper::image_crate_conversion(input, output, target_format.into())
+            }
+            Format::Pdf => self.to_pdf(input, output),
+            _ => Err(ConversionError::UnsupportedOperation),
+        }
     }
-    fn to_bmp(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Bmp)
-    }
-    fn to_tiff(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Tiff)
-    }
-    fn to_png(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Png)
-    }
-    fn to_jpeg(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Jpeg)
-    }
+}
+
+impl GifConverter {
     fn to_pdf(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
         let mut converter = QueueConverter::new();
         converter.push(Format::Png);

--- a/src/converter/img/tiff.rs
+++ b/src/converter/img/tiff.rs
@@ -11,22 +11,24 @@ pub use crate::converter_info::TiffConverter;
 impl Converter for TiffConverter {}
 
 impl ConverterImpl for TiffConverter {
-    fn to_tiff(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        output.clone_from(input);
-        Ok(())
+    fn process(
+        &self,
+        input: &Vec<u8>,
+        output: &mut Vec<u8>,
+        target_format: Format,
+    ) -> Result<(), ConversionError> {
+        match target_format {
+            Format::Tiff => self.to_same_format(input, output),
+            Format::Gif | Format::Png | Format::Jpeg | Format::Bmp => {
+                wrapper::image_crate_conversion(input, output, target_format.into())
+            }
+            Format::Pdf => self.to_pdf(input, output),
+            _ => Err(ConversionError::UnsupportedOperation),
+        }
     }
-    fn to_png(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Png)
-    }
-    fn to_jpeg(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Jpeg)
-    }
-    fn to_bmp(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Bmp)
-    }
-    fn to_gif(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Gif)
-    }
+}
+
+impl TiffConverter {
     fn to_pdf(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
         let mut converter = QueueConverter::new();
         converter.push(Format::Png);

--- a/src/converter/img/webp.rs
+++ b/src/converter/img/webp.rs
@@ -11,25 +11,23 @@ pub use crate::converter_info::WebPConverter;
 impl Converter for WebPConverter {}
 
 impl ConverterImpl for WebPConverter {
-    fn to_webp(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        output.clone_from(input);
-        Ok(())
+    fn process(
+        &self,
+        input: &Vec<u8>,
+        output: &mut Vec<u8>,
+        target_format: Format,
+    ) -> Result<(), ConversionError> {
+        match target_format {
+            Format::WebP=> self.to_same_format(input, output),
+            Format::Tiff | Format::Png | Format::Jpeg | Format::Bmp | Format::Gif=> {
+                wrapper::image_crate_conversion(input, output, target_format.into())
+            }
+            Format::Pdf => self.to_pdf(input, output),
+            _ => Err(ConversionError::UnsupportedOperation),
+        }
     }
-    fn to_bmp(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Bmp)
-    }
-    fn to_tiff(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Tiff)
-    }
-    fn to_png(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Png)
-    }
-    fn to_jpeg(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Jpeg)
-    }
-    fn to_gif(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        wrapper::image_crate_conversion(input, output, ImageFormat::Gif)
-    }
+}
+impl WebPConverter {
     fn to_pdf(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
         let mut converter = QueueConverter::new();
         converter.push(Format::Png);

--- a/src/converter/traits.rs
+++ b/src/converter/traits.rs
@@ -5,45 +5,14 @@ pub trait Converter: ConverterImpl + ConverterInfo {}
 pub trait ConverterImpl {
     fn process(
         &self,
-        input: &Vec<u8>,
-        output: &mut Vec<u8>,
-        target_format: Format,
+        _input: &Vec<u8>,
+        _output: &mut Vec<u8>,
+        _target_format: Format,
     ) -> Result<(), ConversionError> {
-        match target_format {
-            Format::Tiff => self.to_tiff(input, output),
-            Format::Png => self.to_png(input, output),
-            Format::Jpeg => self.to_jpeg(input, output),
-            Format::Bmp => self.to_bmp(input, output),
-            Format::Gif => self.to_gif(input, output),
-            Format::WebP => self.to_webp(input, output),
-            Format::Svg => self.to_svg(input, output),
-            Format::Pdf => self.to_pdf(input, output),
-            _ => Err(ConversionError::UnsupportedOperation),
-        }
+        Err(ConversionError::UnsupportedOperation)
     }
 
-    fn to_png(&self, _input: &Vec<u8>, _output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        Err(ConversionError::UnsupportedOperation)
-    }
-    fn to_jpeg(&self, _input: &Vec<u8>, _output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        Err(ConversionError::UnsupportedOperation)
-    }
-    fn to_tiff(&self, _input: &Vec<u8>, _output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        Err(ConversionError::UnsupportedOperation)
-    }
-    fn to_bmp(&self, _input: &Vec<u8>, _output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        Err(ConversionError::UnsupportedOperation)
-    }
-    fn to_gif(&self, _input: &Vec<u8>, _output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        Err(ConversionError::UnsupportedOperation)
-    }
-    fn to_webp(&self, _input: &Vec<u8>, _output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        Err(ConversionError::UnsupportedOperation)
-    }
-    fn to_svg(&self, _input: &Vec<u8>, _output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        Err(ConversionError::UnsupportedOperation)
-    }
-    fn to_pdf(&self, _input: &Vec<u8>, _output: &mut Vec<u8>) -> Result<(), ConversionError> {
-        Err(ConversionError::UnsupportedOperation)
+    fn to_same_format(&self, input: &Vec<u8>, output: &mut Vec<u8>) -> Result<(), ConversionError> {
+        Ok(output.clone_from(input))
     }
 }

--- a/src/format/interop.rs
+++ b/src/format/interop.rs
@@ -1,0 +1,47 @@
+use image::ImageFormat;
+
+use super::Format;
+
+impl From<ImageFormat> for Format {
+    fn from(format: ImageFormat) -> Self {
+        match format {
+            ImageFormat::Png => Format::Png,
+            ImageFormat::Jpeg => Format::Jpeg,
+            ImageFormat::Gif => Format::Gif,
+            ImageFormat::WebP => Format::WebP,
+            ImageFormat::Pnm => Format::Pnm,
+            ImageFormat::Tiff => Format::Tiff,
+            ImageFormat::Tga => Format::Tga,
+            ImageFormat::Dds => Format::Dds,
+            ImageFormat::Bmp => Format::Bmp,
+            ImageFormat::Ico => Format::Ico,
+            ImageFormat::Hdr => Format::Hdr,
+            ImageFormat::OpenExr => Format::OpenExr,
+            ImageFormat::Farbfeld => Format::Farbfeld,
+            ImageFormat::Avif => Format::Avif,
+            _ => todo!(),
+        }
+    }
+}
+
+impl Into<ImageFormat> for Format {
+    fn into(self) -> ImageFormat {
+        match self {
+            Format::Png => ImageFormat::Png,
+            Format::Jpeg => ImageFormat::Jpeg,
+            Format::Gif => ImageFormat::Gif,
+            Format::WebP => ImageFormat::WebP,
+            Format::Pnm => ImageFormat::Pnm,
+            Format::Tiff => ImageFormat::Tiff,
+            Format::Tga => ImageFormat::Tga,
+            Format::Dds => ImageFormat::Dds,
+            Format::Bmp => ImageFormat::Bmp,
+            Format::Ico => ImageFormat::Ico,
+            Format::Hdr => ImageFormat::Hdr,
+            Format::OpenExr => ImageFormat::OpenExr,
+            Format::Farbfeld => ImageFormat::Farbfeld,
+            Format::Avif => ImageFormat::Avif,
+            _ => todo!(),
+        }
+    }
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -8,6 +8,7 @@
 
 mod enumerator;
 pub mod info;
+mod interop;
 mod utils;
 
 pub use enumerator::Format;


### PR DESCRIPTION
Converters now only have the "process" function instead of multiple "to_format".

This change the API, but should:
- make easier to interpret converters implementations
- make easier to write new converters
- remove useless redundancy in case an underlying library support multiple conversions (like the current image crate wrapper)
