### PR TITLE
Improve user API

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,7 @@ pub struct SizeSetting {
     pub height: u32,
 }
 #[derive(Default, Debug, Clone, Builder, PartialEq)]
+#[builder(default)]
 pub struct ImageOperations {
     pub blur: Option<f32>,
     pub contrast: Option<f32>,
@@ -19,6 +20,7 @@ pub struct ImageOperations {
     pub invert: Option<bool>,
 }
 #[derive(Default, Debug, Clone, Builder, PartialEq)]
+#[builder(default)]
 pub struct ImageConfig {
     pub size: Option<SizeSetting>,
     pub filter: Option<FilterType>,
@@ -26,12 +28,14 @@ pub struct ImageConfig {
     pub operations: Option<ImageOperations>,
 }
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
+#[builder(default)]
 pub struct PngConfig {
     pub base: ImageConfig,
     pub compression: CompressionType,
     pub filter: image::codecs::png::FilterType,
 }
 #[derive(Clone, SmartDefault, Debug, Builder, PartialEq)]
+#[builder(default)]
 pub struct JpegConfig {
     pub base: ImageConfig,
     #[default = 80]
@@ -39,11 +43,13 @@ pub struct JpegConfig {
     pub pixel_density: PixelDensity,
 }
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
+#[builder(default)]
 pub struct BmpConfig {
     pub base: ImageConfig,
 }
 
 #[derive(Clone, SmartDefault, Builder, Debug)]
+#[builder(default)]
 pub struct GifConfig {
     pub base: ImageConfig,
     #[default = 1]
@@ -52,17 +58,21 @@ pub struct GifConfig {
 }
 
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
+#[builder(default)]
 pub struct TiffConfig {
     pub base: ImageConfig,
 }
 
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
+#[builder(default)]
 pub struct WebPConfig {
     pub base: ImageConfig,
 }
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
+#[builder(default)]
 pub struct PdfConfig {}
 #[derive(Clone, Default, Debug, Builder, PartialEq)]
+#[builder(default)]
 pub struct SvgConfig {}
 
 #[non_exhaustive]

--- a/src/converter/img/mod.rs
+++ b/src/converter/img/mod.rs
@@ -18,7 +18,7 @@ pub use webp::WebPConverter;
 
 use crate::{config::Config, format::Format};
 
-use super::{ConversionError, ConversionStrategy};
+use super::{ConversionError, ConversionStrategy, ConverterInfo};
 
 #[non_exhaustive]
 pub enum Converter {
@@ -46,6 +46,18 @@ impl Converter {
             Converter::Bmp(c) => c.process(input, output, config),
             Converter::WebP(c) => c.process(input, output, config),
             Converter::Svg(c) => c.process(input, output, config),
+        }
+    }
+
+    pub fn supported_formats(&self) -> Vec<Format> {
+        match self {
+            Converter::Jpeg(c) => c.supported_formats(),
+            Converter::Png(c) => c.supported_formats(),
+            Converter::Gif(c) => c.supported_formats(),
+            Converter::Tiff(c) => c.supported_formats(),
+            Converter::Bmp(c) => c.supported_formats(),
+            Converter::WebP(c) => c.supported_formats(),
+            Converter::Svg(c) => c.supported_formats(),
         }
     }
 }

--- a/src/format/enumerator.rs
+++ b/src/format/enumerator.rs
@@ -101,4 +101,34 @@ impl Format {
             Format::Pdf => &info::PDF,
         }
     }
+    /// Returns the format type (Audio, Document, Image or Video ) as a FormatKind enumerator
+    pub fn kind(&self) -> FormatKind {
+        match self {
+            Format::Png
+            | Format::Jpeg
+            | Format::Gif
+            | Format::WebP
+            | Format::Pnm
+            | Format::Tiff
+            | Format::Tga
+            | Format::Dds
+            | Format::Bmp
+            | Format::Ico
+            | Format::Hdr
+            | Format::OpenExr
+            | Format::Farbfeld
+            | Format::Avif
+            | Format::Svg => FormatKind::Image,
+            Format::Pdf => FormatKind::Document,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Display, EnumIter, EnumString)]
+#[strum(serialize_all = "PascalCase")]
+pub enum FormatKind {
+    Audio,
+    Document,
+    Image,
+    Video,
 }

--- a/src/format/info/data.rs
+++ b/src/format/info/data.rs
@@ -2,10 +2,6 @@ use super::FormatInfo;
 use crate::format::Format;
 use once_cell::sync::Lazy;
 
-pub static LIST: &[&Lazy<FormatInfo>] = &[
-    &PNG, &JPEG, &GIF, &WEBP, &PNM, &TIFF, &TGA, &DDS, &BMP, &ICO, &HDR, &OPENEXR, &FARBFELD, &AVIF,
-];
-
 pub static PNG: Lazy<FormatInfo> = Lazy::new(|| FormatInfo {
     format: Format::Png,
     extensions: vec!["png"],

--- a/src/format/utils.rs
+++ b/src/format/utils.rs
@@ -1,10 +1,7 @@
-use super::info;
 use super::Format;
-use once_cell::sync::Lazy;
+
+use strum::IntoEnumIterator;
 
 pub fn from_extension(ext: &str) -> Option<Format> {
-    info::LIST
-        .iter()
-        .find(|info| info.extensions.contains(&ext))
-        .map(|info| Lazy::force(info).format)
+    Format::iter().find(|f| f.info().extensions.contains(&ext))
 }


### PR DESCRIPTION
This should:
- Implement `supported_formats()` from the `Converter`
- A Config builder automatically set to default all the unsetted properties
- Reduce the boilerplate to make the format from extension utility work
- Add the `kind()` function to Format, for a quick way to know if it's a document, image or whatever